### PR TITLE
Changes for 2019-01 rollout of ArchivesSpace migration to 2.5.1 (from 1.5.4)

### DIFF
--- a/backend/model/jhu-marc21-overrides.rb
+++ b/backend/model/jhu-marc21-overrides.rb
@@ -7,7 +7,7 @@ class MARCModel < ASpaceExport::ExportModel
   def self.from_resource(obj, opts = {})
     marc = self.from_archival_object(obj, opts)
     marc.apply_map(obj, @resource_map)
-    marc.leader_string = "00000np$aa2200000 i 4500"
+    marc.leader_string = "00000np$aa2200000Ii 4500"
     marc.leader_string[7] = obj.level == 'item' ? 'm' : 'c'
 
     marc.controlfield_string = assemble_controlfield_string(obj)

--- a/backend/model/jhu-marc21-overrides.rb
+++ b/backend/model/jhu-marc21-overrides.rb
@@ -188,8 +188,8 @@ end
                     ['500','a']
                   when 'accessrestrict'
                     ['506','a']
-                  when 'scopecontent'
-                    ['520', '2', ' ', 'a']
+                  # when 'scopecontent'
+                  #   ['520', '2', ' ', 'a']
                   when 'abstract'
                     ['520', '3', ' ', 'a']
                   when 'prefercite'
@@ -199,8 +199,8 @@ end
                     ['541', ind1, ' ', 'a']
                   when 'relatedmaterial'
                     ['544','n']
-                  when 'bioghist'
-                    ['545','a']
+                  # when 'bioghist'
+                  #   ['545','a']
                   when 'custodhist'
                     ind1 = note['publish'] ? '1' : '0'
                     ['561', ind1, ' ', 'a']

--- a/backend/model/jhu-marc21-overrides.rb
+++ b/backend/model/jhu-marc21-overrides.rb
@@ -153,6 +153,11 @@ end
         sfs << ['2', subject['names'].first['source']]
       end
 
+      # move $0 to the end of field, if present
+      # nb: as of 2.5.2, the $0 key is an integer 0, not a string ('0'), as the other keys are
+      sfs = sfs.reject{ |sf, _| sf == '0' || sf == 0 } +
+            sfs.select{ |sf, _| sf == '0' || sf == 0 }
+
       df(code, ind1, ind2, i).with_sfs(*sfs)
     end
   end

--- a/backend/model/jhu-marc21-overrides.rb
+++ b/backend/model/jhu-marc21-overrides.rb
@@ -225,8 +225,12 @@ end
 
       unless marc_args.nil?
         text = prefix ? "#{prefix}: " : ""
-        text += ASpaceExport::Utils.extract_note_text(note)
-        df!(*marc_args[0...-1]).with_sfs([marc_args.last, *Array(text)])
+        text += ASpaceExport::Utils.extract_note_text(note, @include_unpublished, true)
+
+        # only create a tag if there is text to show (e.g., marked published or exporting unpublished)
+        if text.length > 0
+          df!(*marc_args[0...-1]).with_sfs([marc_args.last, *Array(text)])
+        end
       end
 
     end

--- a/backend/model/jhu-marc21-overrides.rb
+++ b/backend/model/jhu-marc21-overrides.rb
@@ -4,8 +4,8 @@ class MARCModel < ASpaceExport::ExportModel
   include JSONModel
 
 #20160621LJD: Leader - Change u at position 18 with i for ISBD per technical services.
-  def self.from_resource(obj)
-    marc = self.from_archival_object(obj)
+  def self.from_resource(obj, opts = {})
+    marc = self.from_archival_object(obj, opts)
     marc.apply_map(obj, @resource_map)
     marc.leader_string = "00000np$aa2200000 i 4500"
     marc.leader_string[7] = obj.level == 'item' ? 'm' : 'c'
@@ -31,7 +31,7 @@ def self.assemble_controlfield_string(obj)
 end
 
 #20160620LJD: 040 - Hard code JHE for 040 $a $e per technical services; add 'eng' to subfield b.
-  def handle_repo_code(repository)
+  def handle_repo_code(repository, langcode)
     repo = repository['_resolved']
     return false unless repo
 
@@ -40,7 +40,7 @@ end
                         ['b', repo['name']],
                         ['e', '3400 N. Charles St. Baltimore, MD 21218']
                       )
-    df('040', ' ', ' ').with_sfs(['a', 'JHE'], ['b', 'eng'], ['c', 'JHE'])
+    df('040', ' ', ' ').with_sfs(['a', 'JHE'], ['b', langcode], ['c', 'JHE'])
   end
 
 #20160621LJD: Change date from 245$f to 264$c per technical services.

--- a/backend/model/jhu-marc21-overrides.rb
+++ b/backend/model/jhu-marc21-overrides.rb
@@ -70,7 +70,7 @@ end
     end
 
     ind1 = creator.nil? ? "0" : "1"
-    df('245', ind1, '0').with_sfs(['a', title])
+    df('245', ind1, '0').with_sfs(['a', title.chomp('.') + '.'])
 
     if date_codes.length > 0
       # put dates in 264$c, but include only 245$f dates

--- a/backend/model/jhu-marc21-overrides.rb
+++ b/backend/model/jhu-marc21-overrides.rb
@@ -198,7 +198,7 @@ end
                     ind1 = note['publish'] ? '1' : '0'
                     ['541', ind1, ' ', 'a']
                   when 'relatedmaterial'
-                    ['544','a']
+                    ['544','n']
                   when 'bioghist'
                     ['545','a']
                   when 'custodhist'

--- a/backend/model/jhu-marc21-overrides.rb
+++ b/backend/model/jhu-marc21-overrides.rb
@@ -79,6 +79,22 @@ end
     end
   end
 
+#20181208 Fix extents: 300$f should contain only the units for the value in 300$a.
+# The container summary can go into 300$. Order should be $a, $f, $b.
+  def handle_extents(extents)
+    extents.each do |ext|
+      e = ext['number']
+      t =  "#{I18n.t('enumerations.extent_extent_type.'+ext['extent_type'], :default => ext['extent_type'])}"
+      extent_subfields = [['a', e], ['f', t]]
+
+      if ext['container_summary']
+        extent_subfields << ['b', ext['container_summary']]
+      end
+
+      df!('300').with_sfs(*extent_subfields)
+    end
+  end
+
 #20160620LJD: Prefercite incorrectly mapped to 534; changed to 524
   def handle_notes(notes)
 

--- a/backend/model/jhu-marc21-overrides.rb
+++ b/backend/model/jhu-marc21-overrides.rb
@@ -3,7 +3,8 @@ class MARCModel < ASpaceExport::ExportModel
 
   include JSONModel
 
-#20160621LJD: Leader - Change u at position 18 with i for ISBD per technical services.
+# Set Encoding Level (ELvl, Leader byte 17) to 'I' (full-level input by OCLC participants)
+# # Set Descriptive Cataloging Form (Desc, Leader byte 18) to 'i' (IBSD punctuation)
   def self.from_resource(obj, opts = {})
     marc = self.from_archival_object(obj, opts)
     marc.apply_map(obj, @resource_map)
@@ -44,7 +45,7 @@ end
     df('049', ' ', ' ').with_sfs(['a', repo['org_code']])
   end
 
-#20160621LJD: Change date from 245$f to 264$c per technical services.
+# Move 245$f dates to 264$c per technical services.
   def handle_title(title, linked_agents, dates)
     creator = linked_agents.find{|a| a['role'] == 'creator'}
     date_codes = []
@@ -79,8 +80,8 @@ end
     end
   end
 
-#20181208 Fix extents: 300$f should contain only the units for the value in 300$a.
-# The container summary can go into 300$. Order should be $a, $f, $b.
+# Fix extents: 300$f should contain only the units for the value in 300$a.
+# The container summary can go into 300$b. Order should be $a, $f, $b.
   def handle_extents(extents)
     extents.each do |ext|
       e = ext['number']

--- a/backend/model/jhu-marc21-overrides.rb
+++ b/backend/model/jhu-marc21-overrides.rb
@@ -41,6 +41,7 @@ end
                         ['e', '3400 N. Charles St. Baltimore, MD 21218']
                       )
     df('040', ' ', ' ').with_sfs(['a', 'JHE'], ['b', langcode], ['c', 'JHE'])
+    df('049', ' ', ' ').with_sfs(['a', repo['org_code']])
   end
 
 #20160621LJD: Change date from 245$f to 264$c per technical services.

--- a/backend/model/jhu-marc21-overrides.rb
+++ b/backend/model/jhu-marc21-overrides.rb
@@ -217,6 +217,8 @@ end
                     ['540', 'a']
                   when 'langmaterial'
                     ['546', 'a']
+                  # when 'otherfindaid'
+                  #   ['555', '0', ' ', 'a']
                   else
                     nil
                   end


### PR DESCRIPTION
Changes based on discussion with @vscripty and Christopher case.

Tracked in [wiki](https://wiki.library.jhu.edu/x/pQAnBQ) and discussion based around [this feedback document](https://wiki.library.jhu.edu/download/attachments/86442149/marc-export-issues.docx).

Details in the commit messages.